### PR TITLE
Add initial mathjax tests

### DIFF
--- a/block.go
+++ b/block.go
@@ -25,6 +25,9 @@ func NewMathJaxBlockParser() parser.BlockParser {
 func (b *mathJaxBlockParser) Open(parent ast.Node, reader text.Reader, pc parser.Context) (ast.Node, parser.State) {
 	line, _ := reader.PeekLine()
 	pos := pc.BlockOffset()
+	if pos == -1 {
+		return nil, parser.NoChildren
+	}
 	if line[pos] != '$' {
 		return nil, parser.NoChildren
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/litao91/goldmark-mathjax
 
 go 1.14
 
-require github.com/yuin/goldmark v1.2.1
+require (
+	github.com/stretchr/testify v1.6.1
+	github.com/yuin/goldmark v1.2.1
+)

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.2.1 h1:ruQGxdhGHe7FWOJPT0mKs5+pD2Xs1Bm/kdGlHO04FmM=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/mathjax_test.go
+++ b/mathjax_test.go
@@ -43,41 +43,11 @@ func TestMathJax(t *testing.T) {
 			out: `<p><span class="math display">\[1+2
 \]</span></p>`,
 		},
-		// TODO: fix this bug.  This input triggers:
-		//
-		// 	panic: runtime error: index out of range [-1] [recovered]
-		// 	panic: runtime error: index out of range [-1]
-
-		// goroutine 24 [running]:
-		// testing.tRunner.func1.1(0x1348dc0, 0xc000170fc0)
-		// 	/usr/local/Cellar/go/1.15.2/libexec/src/testing/testing.go:1076 +0x30d
-		// testing.tRunner.func1(0xc000083380)
-		// 	/usr/local/Cellar/go/1.15.2/libexec/src/testing/testing.go:1079 +0x41a
-		// panic(0x1348dc0, 0xc000170fc0)
-		// 	/usr/local/Cellar/go/1.15.2/libexec/src/runtime/panic.go:969 +0x175
-		// github.com/litao91/goldmark-mathjax.(*mathJaxBlockParser).Open(0x15b28e0, 0x13fdce0, 0xc000175580, 0x13fcee0, 0xc000192770, 0x13fd120, 0xc000192850, 0x1, 0xc000175600, 0x10)
-		// 	/Users/foo/go/src/github.com/pcj/goldmark-mathjax/block.go:28 +0x195
-		// github.com/yuin/goldmark/parser.(*parser).openBlocks(0xc000234a00, 0x13fdce0, 0xc000175580, 0x0, 0x13fcee0, 0xc000192770, 0x13fd120, 0xc000192850, 0x2)
-		// 	/Users/foo/go/pkg/mod/github.com/yuin/goldmark@v1.2.1/parser/parser.go:938 +0x26c
-		// github.com/yuin/goldmark/parser.(*parser).parseBlocks(0xc000234a00, 0x13fdce0, 0xc000175580, 0x13fcee0, 0xc000192770, 0x13fd120, 0xc000192850)
-		// 	/Users/foo/go/pkg/mod/github.com/yuin/goldmark@v1.2.1/parser/parser.go:1082 +0x2df
-		// github.com/yuin/goldmark/parser.(*parser).Parse(0xc000234a00, 0x13fcee0, 0xc000192770, 0x0, 0x0, 0x0, 0x8, 0x8)
-		// 	/Users/foo/go/pkg/mod/github.com/yuin/goldmark@v1.2.1/parser/parser.go:848 +0x145
-		// github.com/yuin/goldmark.(*markdown).Convert(0xc0000cef80, 0xc000173948, 0x7, 0x8, 0x13f73a0, 0xc00018ea80, 0x0, 0x0, 0x0, 0x149bd20, ...)
-		// 	/Users/foo/go/pkg/mod/github.com/yuin/goldmark@v1.2.1/markdown.go:116 +0x96
-		// github.com/litao91/goldmark-mathjax.renderMarkdown(0x13684d4, 0x7, 0x133be381, 0x958c133be381, 0x100000001, 0xc00003e748)
-		// 	/Users/foo/go/src/github.com/pcj/goldmark-mathjax/mathjax_test.go:87 +0x1d4
-		// github.com/litao91/goldmark-mathjax.TestMathJax.func1(0xc000083380)
-		// 	/Users/foo/go/src/github.com/pcj/goldmark-mathjax/mathjax_test.go:56 +0x4e
-		// testing.tRunner(0xc000083380, 0xc000220dd0)
-		// 	/usr/local/Cellar/go/1.15.2/libexec/src/testing/testing.go:1127 +0xef
-		// created by testing.(*T).Run
-		// 	/usr/local/Cellar/go/1.15.2/libexec/src/testing/testing.go:1178 +0x386
-		// FAIL	github.com/litao91/goldmark-mathjax	0.261s
 		{
-			d:   "list-bug",
+			// this input previously triggered a panic in block.go
+			d:   "list-begin",
 			in:  "*foo\n  ",
-			out: "<p>*foo</p>\n",
+			out: "<p>*foo</p>",
 		},
 	}
 

--- a/mathjax_test.go
+++ b/mathjax_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/yuin/goldmark"
-	"github.com/yuin/goldmark/parser"
-	"github.com/yuin/goldmark/renderer"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -53,40 +51,25 @@ func TestMathJax(t *testing.T) {
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d: %s", i, tc.d), func(t *testing.T) {
-			out, err := renderMarkdown(tc.in)
+			out, err := renderMarkdown([]byte(tc.in))
 			if err != nil {
 				t.Fatal(err)
 			}
-			assert.Equal(t, tc.out, out)
+			assert.Equal(t, tc.out, strings.TrimSpace(string(out)))
 		})
 	}
 
 }
 
-func renderMarkdown(src string) (string, error) {
-	var parserOptions []parser.Option
-	var rendererOptions []renderer.Option
-
-	extensions := []goldmark.Extender{
-		MathJax,
-	}
-
+func renderMarkdown(src []byte) ([]byte, error) {
 	md := goldmark.New(
-		goldmark.WithExtensions(
-			extensions...,
-		),
-		goldmark.WithParserOptions(
-			parserOptions...,
-		),
-		goldmark.WithRendererOptions(
-			rendererOptions...,
-		),
+		goldmark.WithExtensions(MathJax),
 	)
 
 	var buf bytes.Buffer
-	if err := md.Convert([]byte(src), &buf); err != nil {
-		return "", err
+	if err := md.Convert(src, &buf); err != nil {
+		return nil, err
 	}
 
-	return strings.TrimSpace(buf.String()), nil
+	return buf.Bytes(), nil
 }

--- a/mathjax_test.go
+++ b/mathjax_test.go
@@ -1,0 +1,122 @@
+package mathjax
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mathJaxTestCase struct {
+	d   string // test description
+	in  string // input markdown source
+	out string // expected output html
+}
+
+func TestMathJax(t *testing.T) {
+
+	tests := []mathJaxTestCase{
+		{
+			d:   "plain text",
+			in:  "foo",
+			out: `<p>foo</p>`,
+		},
+		{
+			d:   "bold",
+			in:  "**foo**",
+			out: `<p><strong>foo</strong></p>`,
+		},
+		{
+			d:   "math inline",
+			in:  "$1+2$",
+			out: `<p><span class="math inline">\(1+2\)</span></p>`,
+		},
+		{
+			d:  "math display",
+			in: "$$\n1+2\n$$",
+			out: `<p><span class="math display">\[1+2
+\]</span></p>`,
+		},
+		// TODO: fix this bug.  This input triggers:
+		//
+		// 	panic: runtime error: index out of range [-1] [recovered]
+		// 	panic: runtime error: index out of range [-1]
+
+		// goroutine 24 [running]:
+		// testing.tRunner.func1.1(0x1348dc0, 0xc000170fc0)
+		// 	/usr/local/Cellar/go/1.15.2/libexec/src/testing/testing.go:1076 +0x30d
+		// testing.tRunner.func1(0xc000083380)
+		// 	/usr/local/Cellar/go/1.15.2/libexec/src/testing/testing.go:1079 +0x41a
+		// panic(0x1348dc0, 0xc000170fc0)
+		// 	/usr/local/Cellar/go/1.15.2/libexec/src/runtime/panic.go:969 +0x175
+		// github.com/litao91/goldmark-mathjax.(*mathJaxBlockParser).Open(0x15b28e0, 0x13fdce0, 0xc000175580, 0x13fcee0, 0xc000192770, 0x13fd120, 0xc000192850, 0x1, 0xc000175600, 0x10)
+		// 	/Users/foo/go/src/github.com/pcj/goldmark-mathjax/block.go:28 +0x195
+		// github.com/yuin/goldmark/parser.(*parser).openBlocks(0xc000234a00, 0x13fdce0, 0xc000175580, 0x0, 0x13fcee0, 0xc000192770, 0x13fd120, 0xc000192850, 0x2)
+		// 	/Users/foo/go/pkg/mod/github.com/yuin/goldmark@v1.2.1/parser/parser.go:938 +0x26c
+		// github.com/yuin/goldmark/parser.(*parser).parseBlocks(0xc000234a00, 0x13fdce0, 0xc000175580, 0x13fcee0, 0xc000192770, 0x13fd120, 0xc000192850)
+		// 	/Users/foo/go/pkg/mod/github.com/yuin/goldmark@v1.2.1/parser/parser.go:1082 +0x2df
+		// github.com/yuin/goldmark/parser.(*parser).Parse(0xc000234a00, 0x13fcee0, 0xc000192770, 0x0, 0x0, 0x0, 0x8, 0x8)
+		// 	/Users/foo/go/pkg/mod/github.com/yuin/goldmark@v1.2.1/parser/parser.go:848 +0x145
+		// github.com/yuin/goldmark.(*markdown).Convert(0xc0000cef80, 0xc000173948, 0x7, 0x8, 0x13f73a0, 0xc00018ea80, 0x0, 0x0, 0x0, 0x149bd20, ...)
+		// 	/Users/foo/go/pkg/mod/github.com/yuin/goldmark@v1.2.1/markdown.go:116 +0x96
+		// github.com/litao91/goldmark-mathjax.renderMarkdown(0x13684d4, 0x7, 0x133be381, 0x958c133be381, 0x100000001, 0xc00003e748)
+		// 	/Users/foo/go/src/github.com/pcj/goldmark-mathjax/mathjax_test.go:87 +0x1d4
+		// github.com/litao91/goldmark-mathjax.TestMathJax.func1(0xc000083380)
+		// 	/Users/foo/go/src/github.com/pcj/goldmark-mathjax/mathjax_test.go:56 +0x4e
+		// testing.tRunner(0xc000083380, 0xc000220dd0)
+		// 	/usr/local/Cellar/go/1.15.2/libexec/src/testing/testing.go:1127 +0xef
+		// created by testing.(*T).Run
+		// 	/usr/local/Cellar/go/1.15.2/libexec/src/testing/testing.go:1178 +0x386
+		// FAIL	github.com/litao91/goldmark-mathjax	0.261s
+		{
+			d:   "list-bug",
+			in:  "*foo\n  ",
+			out: "<p>*foo</p>\n",
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d: %s", i, tc.d), func(t *testing.T) {
+			out, err := renderMarkdown(tc.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tc.out, out)
+		})
+	}
+
+}
+
+func renderMarkdown(src string) (string, error) {
+	var parserOptions []parser.Option
+	var rendererOptions []renderer.Option
+
+	extensions := []goldmark.Extender{
+		MathJax,
+	}
+
+	md := goldmark.New(
+		goldmark.WithExtensions(
+			extensions...,
+		),
+		goldmark.WithParserOptions(
+			parserOptions...,
+		),
+		goldmark.WithRendererOptions(
+			rendererOptions...,
+		),
+	)
+
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(src), &buf); err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(buf.String()), nil
+}


### PR DESCRIPTION
Opening this PR to add tests. 

The commented out one should be addressed in a future PR.  The mathjax extension does not play nice with that particular input.

To run the tests, do

```
$ go test .
```